### PR TITLE
Docs: change reference to stable official documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ vendor/bin/phpunit --filter=<TEST_METHOD_NAME>
 
 ## Read Official Documentation
 
-Of course, this repository cannot replace the [official documentation](https://docs.mockery.io/en/latest/) and does not cover all of PHP Mockery's features. To fully understand Mockery's capabilities, we highly encourage you to read the official documentation. Use this repository as a supplementary resource with simple explanations and prepared tests.
+Of course, this repository cannot replace the [official documentation](https://docs.mockery.io/en/stable/index.html) and does not cover all of PHP Mockery's features. To fully understand Mockery's capabilities, we highly encourage you to read the official documentation. Use this repository as a supplementary resource with simple explanations and prepared tests.
 
 ## Contributing
 

--- a/tests/A_MakingMockTest.php
+++ b/tests/A_MakingMockTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * This test class explains the `Creating Test Doubles` section.
  *
- * Official documentation: https://docs.mockery.io/en/latest/reference/creating_test_doubles.html
+ * Official documentation: https://docs.mockery.io/en/stable/reference/creating_test_doubles.html
  */
 class A_MakingMockTest extends TestCase
 {
@@ -56,7 +56,7 @@ class A_MakingMockTest extends TestCase
         | To simplify tests, we can chain the `shouldIgnoreMissing()` method to prevent
         | tests from breaking for undefined methods.
         | In this case, undefined methods will return `null`, `0`, `false`, `''`, or `[]` based on their return type.
-        | Please check the returned values here: https://docs.mockery.io/en/latest/reference/creating_test_doubles.html#behavior-modifiers
+        | Please check the returned values here: https://docs.mockery.io/en/stable/reference/creating_test_doubles.html#behavior-modifiers
         |
         | If your code includes validations for their output, such as `!empty()` or `!is_null()`, it may fail.
         */
@@ -185,7 +185,7 @@ class A_MakingMockTest extends TestCase
         |
         | Note: When you create a spy, methods won't work normally, and we can't define expectations like in a mock;
         | they ALWAYS return `null`, `0`, `false`, `''`, or `[]` based on their return type.
-        | Please check the returned values here: https://docs.mockery.io/en/latest/reference/creating_test_doubles.html#behavior-modifiers
+        | Please check the returned values here: https://docs.mockery.io/en/stable/reference/creating_test_doubles.html#behavior-modifiers
         |
         | If your code includes validations for their output, such as `!empty()` or `!is_null()`, it will fail.
         |


### PR DESCRIPTION
Documentation link is updated to the stable version of Mockery's documentation.