### PR TITLE
Refactor: use symphony var-dumper to show beautiful console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0] - 2025-04-13
+
+### Added
+
+- `symfony/var-dumper` package to show output more beautiful in the console.
+
 ## [1.1.0] - 2025-04-03
 
 ### Added
@@ -20,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - The first release of this package.
 - Includes explanations and examples for [making mock/spy] objects.
 
+[1.2.0]: https://github.com/amyavari/php-mockery-examples-and-explanations/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/amyavari/php-mockery-examples-and-explanations/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/amyavari/php-mockery-examples-and-explanations/compare/d6e594f...v1.0.0
 [Expectation Declarations]: https://docs.mockery.io/en/stable/reference/expectations.html

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ git clone https://github.com/amyavari/php-mockery-examples-and-explanations.git
 composer install
 ```
 
-It will install `mockery/mockery`, `phpunit/phpunit` and `laravel/pint`.
+It will install `mockery/mockery`, `phpunit/phpunit`, `laravel/pint` and `symfony/var-dumper`.
 
 3. Explore the [`./tests`](./tests/) directory, where each file corresponds to a specific section of Mockery official documentation. Each test file contains multiple test cases which the method names represents the concept it will explain and test.
 
@@ -40,7 +40,7 @@ It will install `mockery/mockery`, `phpunit/phpunit` and `laravel/pint`.
    - Feel free to modify the tests as instructed in the doc comments or as needed to explore different scenarios
    - Don't forget to check [`./src`](./src) directory to understand the code being tested
 
-4. Check the output in your command-line interface, including errors, warnings, and `var_dump` outputs.
+4. Check the output in your command-line interface, including errors, warnings, and `dump` outputs.
 
 ## Table of Contents
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
     "require-dev": {
         "mockery/mockery": "^1.6",
         "phpunit/phpunit": "^12.0",
-        "laravel/pint": "^1.21"
+        "laravel/pint": "^1.21",
+        "symfony/var-dumper": "^7.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e20740088bdecba65eb3cbf56324108d",
+    "content-hash": "ea55752f0833229b65e6976f8d6a5e22",
     "packages": [],
     "packages-dev": [
         {
@@ -1726,6 +1726,169 @@
                 }
             ],
             "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v7.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "82b478c69745d8878eb60f9a049a4d584996f73a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/82b478c69745d8878eb60f9a049a4d584996f73a",
+                "reference": "82b478c69745d8878eb60f9a049a4d584996f73a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "ext-iconv": "*",
+                "symfony/console": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/uid": "^6.4|^7.0",
+                "twig/twig": "^3.12"
+            },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides mechanisms for walking through any arbitrary PHP variable",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-dumper/tree/v7.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-01-17T11:39:41+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/tests/A_MakingMock_Test.php
+++ b/tests/A_MakingMock_Test.php
@@ -42,7 +42,7 @@ class A_MakingMock_Test extends TestCase
         $main = new Main($mockedDependencyOne, new DependencyTwo);
         $output = $main->run();
 
-        var_dump($output); // The output of calling `DependencyOne` methods is as above!
+        dump($output); // The output of calling `DependencyOne` methods is as above!
 
         $this->assertInstanceOf(Main::class, $main);
     }
@@ -73,7 +73,7 @@ class A_MakingMock_Test extends TestCase
         $main = new Main($mockedDependencyOne, new DependencyTwo);
         $output = $main->run();
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }
@@ -111,7 +111,7 @@ class A_MakingMock_Test extends TestCase
         $main = new Main($mockedDependencyOne, new DependencyTwo);
         $output = $main->run();
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }
@@ -140,7 +140,7 @@ class A_MakingMock_Test extends TestCase
         $main = new Main($mockedDependencyOne, new DependencyTwo);
         $output = $main->run();
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }
@@ -165,7 +165,7 @@ class A_MakingMock_Test extends TestCase
         $main = new Main($mockedDependencyOne, new DependencyTwo);
         $output = $main->run();
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }
@@ -186,7 +186,7 @@ class A_MakingMock_Test extends TestCase
         $main = new Main($mockedDependencyOne, new DependencyTwo);
         $output = $main->run();
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }
@@ -222,7 +222,7 @@ class A_MakingMock_Test extends TestCase
         $spyDependencyOne->shouldHaveReceived('setNameProperty', ['Ali']);
         $spyDependencyOne->shouldHaveReceived('getNameProperty');
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }

--- a/tests/B_Expectations_Part1_Test.php
+++ b/tests/B_Expectations_Part1_Test.php
@@ -50,7 +50,7 @@ class B_Expectations_Part1_Test extends TestCase
         $main = new Main($mockedDependencyOne, new DependencyTwo);
         $output = $main->run();
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }
@@ -70,7 +70,7 @@ class B_Expectations_Part1_Test extends TestCase
         $main = new Main($mockedDependencyOne, new DependencyTwo);
         $output = $main->run();
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }
@@ -115,7 +115,7 @@ class B_Expectations_Part1_Test extends TestCase
         $main = new Main($mockedDependencyOne, $mockedDependencyTwo);
         $output = $main->run();
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }
@@ -157,7 +157,7 @@ class B_Expectations_Part1_Test extends TestCase
         $main = new Main($mockedDependencyOne, $mockedDependencyTwo);
         $output = $main->run();
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }
@@ -183,7 +183,7 @@ class B_Expectations_Part1_Test extends TestCase
         $main = new Main($mockedDependencyOne, new DependencyTwo);
         $output = $main->run();
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }

--- a/tests/B_Expectations_Part2_Test.php
+++ b/tests/B_Expectations_Part2_Test.php
@@ -45,7 +45,7 @@ class B_Expectations_Part2_Test extends TestCase
         $main = new Main($mockedDependencyOne, new DependencyTwo);
         $output = $main->repeatedMethodCalls();
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }
@@ -79,7 +79,7 @@ class B_Expectations_Part2_Test extends TestCase
         $main = new Main($mockedDependencyOne, new DependencyTwo);
         $output = $main->repeatedMethodCalls();
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }
@@ -105,7 +105,7 @@ class B_Expectations_Part2_Test extends TestCase
         $main = new Main(new DependencyOne, $mockedDependencyTwo);
         $output = $main->run();
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }
@@ -141,7 +141,7 @@ class B_Expectations_Part2_Test extends TestCase
         $main = new Main($mockedDependencyOne, new DependencyTwo);
         $output = $main->run();
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }

--- a/tests/B_Expectations_Part3_Test.php
+++ b/tests/B_Expectations_Part3_Test.php
@@ -70,7 +70,7 @@ class B_Expectations_Part3_Test extends TestCase
         $main = new Main($mockedDependencyOne, new DependencyTwo);
         $output = $main->repeatedMethodCalls();
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }
@@ -108,7 +108,7 @@ class B_Expectations_Part3_Test extends TestCase
         $main = new Main($mockedDependencyOne, new DependencyTwo);
         $output = $main->repeatedMethodCalls(num1: 111, num2: 222, num3: 333, num4: 333);
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }
@@ -151,7 +151,7 @@ class B_Expectations_Part3_Test extends TestCase
         $main = new Main($mockedDependencyOne, $mockedDependencyTwo);
         $output = $main->run();
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }
@@ -189,7 +189,7 @@ class B_Expectations_Part3_Test extends TestCase
         $main = new Main($mockedDependencyOne, new DependencyTwo);
         $output = $main->run();
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }
@@ -221,7 +221,7 @@ class B_Expectations_Part3_Test extends TestCase
         $main = new Main($mockedDependencyOne, $mockedDependencyTwo);
         $output = $main->run();
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }
@@ -256,7 +256,7 @@ class B_Expectations_Part3_Test extends TestCase
         $main = new Main($mockedDependencyOne, new DependencyTwo);
         $output = $main->repeatedMethodCalls();
 
-        var_dump($output);
+        dump($output);
 
         $this->assertInstanceOf(Main::class, $main);
     }


### PR DESCRIPTION
### What is the reason for this PR?

`symphony/var-dumper` package is added to make output in the console more beautiful.

- [ ] A new feature/example/test case
- [x] Improved explanations
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] New features and changes are documented in the [CHANGELOG.md](../CHANGELOG.md)
- [x] Relevant sections in [README.md](../README.md) are updated

### Summary of changes

- `symfony/var-dumper` package is added.

### Review checklist

- [x] Changes are properly documented
- [ ] Examples/explanations demonstrate Mockery concepts effectively
- [x] Changes are approved by maintainer
