### PR TITLE
Feature: add pass-by-reference, megic methods and method chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.0] - 2025-04-30
+
+### Added
+
+- Explanations and examples for [Preserving Pass-By-Reference Method Parameter Behavior]
+- Explanations and examples for [Mocking Demeter Chains And Fluent Interfaces]
+- Explanations and examples for [PHP Magic Methods]
+
 ## [1.3.0] - 2025-04-21
 
 ### Added
@@ -34,10 +42,14 @@ All notable changes to this project will be documented in this file.
 - The first release of this package.
 - Includes explanations and examples for [making mock/spy] objects.
 
+[1.4.0]: https://github.com/amyavari/php-mockery-examples-and-explanations/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/amyavari/php-mockery-examples-and-explanations/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/amyavari/php-mockery-examples-and-explanations/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/amyavari/php-mockery-examples-and-explanations/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/amyavari/php-mockery-examples-and-explanations/compare/d6e594f...v1.0.0
+[Preserving Pass-By-Reference Method Parameter Behavior]: https://docs.mockery.io/en/stable/reference/pass_by_reference_behaviours.html
+[Mocking Demeter Chains And Fluent Interfaces]: https://docs.mockery.io/en/stable/reference/demeter_chains.html
+[PHP Magic Methods]: https://docs.mockery.io/en/stable/reference/magic_methods.html
 [Argument Validation]: https://docs.mockery.io/en/stable/reference/argument_validation.html
 [Alternative shouldReceive Syntax for mocks]: https://docs.mockery.io/en/stable/reference/alternative_should_receive_syntax.html
 [Alternative shouldReceive Syntax for spies]: https://docs.mockery.io/en/stable/reference/spies.html#alternative-shouldreceive-syntax

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Each section below links to the relevant part of the [Mockery documentation](htt
 - **[Expectation Declaration Utilities](https://docs.mockery.io/en/stable/reference/expectations.html#expectation-declaration-utilities)** → [`B_Expectations_Part3_Test.php`](./tests/B_Expectations_Part3_Test.php)
 - **[Argument Validation](https://docs.mockery.io/en/stable/reference/argument_validation.html)** → [`C_Argument_Validation_Test.php`](./tests/C_Argument_Validation_Test.php)
 - **[Alternative shouldReceive Syntax](https://docs.mockery.io/en/stable/reference/alternative_should_receive_syntax.html)** → [`D_Alternative_Should_Test.php`](./tests/D_Alternative_Should_Test.php)
+- **[Preserving Pass-By-Reference Method Parameter Behavior](https://docs.mockery.io/en/stable/reference/pass_by_reference_behaviours.html)** → [`E_Other_Features_Test.php`](./tests/E_Other_Features_Test.php)
+- **[Mocking Demeter Chains And Fluent Interfaces](https://docs.mockery.io/en/stable/reference/demeter_chains.html)** → [`E_Other_Features_Test.php`](./tests/E_Other_Features_Test.php)
+- **[PHP Magic Methods](https://docs.mockery.io/en/stable/reference/magic_methods.html)** → [`E_Other_Features_Test.php`](./tests/E_Other_Features_Test.php)
+
 
 ## Changes
 

--- a/src/DependencyThree.php
+++ b/src/DependencyThree.php
@@ -40,4 +40,9 @@ class DependencyThree
 
         return $this->data;
     }
+
+    public function __call($name, $arguments)
+    {
+        return $name;
+    }
 }

--- a/src/DependencyThree.php
+++ b/src/DependencyThree.php
@@ -6,8 +6,38 @@ namespace App;
 
 class DependencyThree
 {
+    protected array $data;
+
     public function multipleByTen(int &$number): void
     {
         $number *= 10;
+    }
+
+    public function addNumber(int $number): self
+    {
+        $this->data['number'] = $number;
+
+        return $this;
+    }
+
+    public function addString(string $string): self
+    {
+        $this->data['string'] = $string;
+
+        return $this;
+    }
+
+    public function addBool(bool $bool): self
+    {
+        $this->data['bool'] = $bool;
+
+        return $this;
+    }
+
+    public function finalAdd(mixed $final): array
+    {
+        $this->data['final'] = $final;
+
+        return $this->data;
     }
 }

--- a/src/DependencyThree.php
+++ b/src/DependencyThree.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App;
 
+/**
+ * Only used by `MainTwo` class.
+ */
 class DependencyThree
 {
     protected array $data;

--- a/src/DependencyThree.php
+++ b/src/DependencyThree.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+class DependencyThree
+{
+    public function multipleByTen(int &$number): void
+    {
+        $number *= 10;
+    }
+}

--- a/src/MainTwo.php
+++ b/src/MainTwo.php
@@ -28,4 +28,11 @@ class MainTwo
             'dependency_three->addNumber(10)->addString("Ali")->addBool(true)->finalAdd("Wow")' => $output,
         ];
     }
+
+    public function magicOrVirtualMethod(): array
+    {
+        return [
+            'dependency_three->notExistedMethod(123, "Ali")' => $this->dependencyThree->notExistedMethod(123, "Ali"),
+        ];
+    }
 }

--- a/src/MainTwo.php
+++ b/src/MainTwo.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+class MainTwo
+{
+    public function __construct(protected DependencyThree $dependencyThree) {}
+
+    public function passedByReference(): array
+    {
+        $number = 4;
+
+        $this->dependencyThree->multipleByTen($number); // This changes number to 40
+
+        return [
+            'dependency_three->multipleByTen(4)' => $number,
+        ];
+    }
+}

--- a/src/MainTwo.php
+++ b/src/MainTwo.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App;
 
+/**
+ * Only used by `E_Other_Features_Test` class.
+ */
 class MainTwo
 {
     public function __construct(protected DependencyThree $dependencyThree) {}
@@ -31,8 +34,9 @@ class MainTwo
 
     public function magicOrVirtualMethod(): array
     {
+        // Output is: ['dependency_three->notExistedMethod(123, "Ali")' => 'notExistedMethod']
         return [
-            'dependency_three->notExistedMethod(123, "Ali")' => $this->dependencyThree->notExistedMethod(123, "Ali"),
+            'dependency_three->notExistedMethod(123, "Ali")' => $this->dependencyThree->notExistedMethod(123, 'Ali'),
         ];
     }
 }

--- a/src/MainTwo.php
+++ b/src/MainTwo.php
@@ -18,4 +18,14 @@ class MainTwo
             'dependency_three->multipleByTen(4)' => $number,
         ];
     }
+
+    public function chainedMethods(): array
+    {
+        // Output is:  ['number' => 10, 'string' => 'Ali', 'bool' => true, 'final' => 'Wow']
+        $output = $this->dependencyThree->addNumber(10)->addString('Ali')->addBool(true)->finalAdd('Wow');
+
+        return [
+            'dependency_three->addNumber(10)->addString("Ali")->addBool(true)->finalAdd("Wow")' => $output,
+        ];
+    }
 }

--- a/tests/E_Other_Features_Test.php
+++ b/tests/E_Other_Features_Test.php
@@ -50,4 +50,34 @@ class E_Other_Features_Test extends TestCase
 
         $this->assertInstanceOf(MainTwo::class, $main);
     }
+
+    public function test_mocking_chained_methods_and_fluent_interfaces(): void
+    {
+        /*
+        | For chained methods (fluent interface), Mockery lets you mock
+        | the entire chain at once without needing to mock each method call.
+        */
+        $mockedDependencyThree = Mockery::mock(DependencyThree::class);
+
+        /*
+        | For chained methods, use this format:
+        | - `$mocked->shouldReceive('methodOne->methodTwo->...')`; (method names without parentheses/arguments, separated by `->`)
+        | - Only validate arguments on the final method call if needed
+        | - Only set the final return value for the entire chain
+        |
+        | This single line replaces these 4:
+        |   $mockedDependencyThree->shouldReceive('addNumber')->andReturnSelf();
+        |   $mockedDependencyThree->shouldReceive('addString')->andReturnSelf();
+        |   $mockedDependencyThree->shouldReceive('addBool')->andReturnSelf();
+        |   $mockedDependencyThree->shouldReceive('finalAdd')->with('Wow')->andReturn(['nothing' => 'nothing']);
+        */
+        $mockedDependencyThree->shouldReceive('addNumber->addString->addBool->finalAdd')->with('Wow')->andReturn(['nothing' => 'nothing']);
+
+        $main = new MainTwo($mockedDependencyThree);
+        $output = $main->chainedMethods();
+
+        dump($output);
+
+        $this->assertInstanceOf(MainTwo::class, $main);
+    }
 }

--- a/tests/E_Other_Features_Test.php
+++ b/tests/E_Other_Features_Test.php
@@ -80,4 +80,32 @@ class E_Other_Features_Test extends TestCase
 
         $this->assertInstanceOf(MainTwo::class, $main);
     }
+
+    public function test_mocking_magic_or_virtual_methods(): void
+    {
+        /*
+        | For magic methods, declare expectations exactly like virtual methods -
+        | just mock them like normal method calls.
+
+        | Note: Virtual methods are methods that don't exist in the real class.
+        |       This is useful when your code depends on undeveloped classes.
+        |       Mockery doesn't check method existence - it only verifies
+        |       declared expectations and returns the specified values.
+        */
+        $mockedDependencyThree = Mockery::mock(DependencyThree::class);
+
+        /*
+        | In `DependencyThree`, we have `__call()` magic method, not `notExistedMethod()`.
+        | It doesn't matter if you remove `__call()` or not - Mockery will still
+        | return the expectation for `notExistedMethod()` call we declared here.
+        */
+        $mockedDependencyThree->shouldReceive('notExistedMethod')->with(123, 'Ali')->andReturn('I don\'n exist! Can you believe?');
+
+        $main = new MainTwo($mockedDependencyThree);
+        $output = $main->magicOrVirtualMethod();
+
+        dump($output);
+
+        $this->assertInstanceOf(MainTwo::class, $main);
+    }
 }

--- a/tests/E_Other_Features_Test.php
+++ b/tests/E_Other_Features_Test.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use App\DependencyThree;
+use App\MainTwo;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * This test class explains these sections:
+ *  - Preserving Pass-By-Reference Method Parameter Behavior: https://docs.mockery.io/en/stable/reference/pass_by_reference_behaviours.html
+ *  - Mocking Demeter Chains And Fluent Interfaces: https://docs.mockery.io/en/stable/reference/demeter_chains.html
+ *  - PHP Magic Methods: https://docs.mockery.io/en/stable/reference/magic_methods.html
+ *
+ * Note: This file uses `DependencyThree` and `MainTwo` classes to keep things separated and organized.
+ */
+class E_Other_Features_Test extends TestCase
+{
+    public function test_pass_by_reference_for_method_parameter(): void
+    {
+        /*
+        | As expected, since the mocked method won't execute normally,
+        | if your method accepts parameters by reference, the values won't change.
+        | In this case, if you need to modify these parameters,
+        | you must handle it manually using closures.
+        */
+        $mockedDependencyThree = Mockery::mock(DependencyThree::class);
+
+        /*
+        | Exactly as expected, `withArgs()` can receive reference arguments
+        | and lets you modify their values inside the closure.
+        |
+        | Note: You must return `true` to pass Mockery's argument validation
+        | Note: The `setInternalClassMethodParamMap()` method (explained in official docs)
+        |       is incompatible with PHP 8+
+        */
+        $mockedDependencyThree->shouldReceive('multipleByTen')->withArgs(function (&$number) {
+            $number *= 2;
+
+            return true;
+        });
+
+        $main = new MainTwo($mockedDependencyThree);
+        $output = $main->passedByReference();
+
+        dump($output);
+
+        $this->assertInstanceOf(MainTwo::class, $main);
+    }
+}


### PR DESCRIPTION
### What is the reason for this PR?

Examples and explanations for `pass-by-reference`, `chained methods`, and `magic methods` are added.

- [x] A new feature/example/test case
- [ ] Improved explanations
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] New features and changes are documented in the [CHANGELOG.md](../CHANGELOG.md)
- [x] Relevant sections in [README.md](../README.md) are updated

### Summary of changes

- Added examples and explanations for `pass-by-reference parameters`
- Added examples and explanations for `chained methods`
- Added examples and explanations for `magic methods`

### Review checklist

- [x] Changes are properly documented
- [x] Examples/explanations demonstrate Mockery concepts effectively
- [x] Changes are approved by maintainer
