### PR TITLE
Feature: add package to bypass restriction of mocking final classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.5.0] - 2025-05-12
+
+### Updated
+
+- Explanations and examples for mocking `final` classes - introducing [nunomaduro/mock-final-classes]
+
 ## [1.4.0] - 2025-04-30
 
 ### Added
@@ -42,11 +48,13 @@ All notable changes to this project will be documented in this file.
 - The first release of this package.
 - Includes explanations and examples for [making mock/spy] objects.
 
+[1.5.0]: https://github.com/amyavari/php-mockery-examples-and-explanations/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/amyavari/php-mockery-examples-and-explanations/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/amyavari/php-mockery-examples-and-explanations/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/amyavari/php-mockery-examples-and-explanations/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/amyavari/php-mockery-examples-and-explanations/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/amyavari/php-mockery-examples-and-explanations/compare/d6e594f...v1.0.0
+[nunomaduro/mock-final-classes]: https://github.com/nunomaduro/mock-final-classes
 [Preserving Pass-By-Reference Method Parameter Behavior]: https://docs.mockery.io/en/stable/reference/pass_by_reference_behaviours.html
 [Mocking Demeter Chains And Fluent Interfaces]: https://docs.mockery.io/en/stable/reference/demeter_chains.html
 [PHP Magic Methods]: https://docs.mockery.io/en/stable/reference/magic_methods.html

--- a/tests/A_MakingMock_Test.php
+++ b/tests/A_MakingMock_Test.php
@@ -230,6 +230,11 @@ class A_MakingMock_Test extends TestCase
     public function test_create_mock_for_final_classes_and_methods(): void
     {
         /*
+        | Note: You can bypass mock restrictions (mentioned below)
+        |       using this package: https://github.com/nunomaduro/mock-final-classes
+        */
+
+        /*
         | As Mockery states in its official documentation, it creates a new class
         | and extends our dependency class/interface/abstract class to create a mock object from it.
         | This new class will override methods based on our expectations, so:


### PR DESCRIPTION
### What is the reason for this PR?

A package to bypass restriction of mocking `final` classes is introduced.

- [x] A new feature/example/test case
- [ ] Improved explanations
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] New features and changes are documented in the [CHANGELOG.md](../CHANGELOG.md)
- [x] Relevant sections in [README.md](../README.md) are updated

### Summary of changes

- Updated explanations and examples for mocking `final` classes - introducing [nunomaduro/mock-final-classes](https://github.com/nunomaduro/mock-final-classes)

### Review checklist

- [x] Changes are properly documented
- [x] Examples/explanations demonstrate Mockery concepts effectively
- [x] Changes are approved by maintainer
